### PR TITLE
fix JENKINS-48885

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,21 @@ plugins {
     jacoco
     id("com.mkobit.jenkins.pipelines.shared-library") version "0.10.1"
     id("com.github.ben-manes.versions") version "0.28.0"
+    id("org.jenkins-ci.jpi") version "0.38.0" apply false
+}
+
+tasks {
+
+    register<org.jenkinsci.gradle.plugins.jpi.TestDependenciesTask>("resolveIntegrationTestDependencies") {
+        into {
+            val javaConvention = project.convention.getPlugin<JavaPluginConvention>()
+            File("${javaConvention.sourceSets.integrationTest.get().output.resourcesDir}/test-dependencies")
+        }
+        configuration = configurations.integrationTestRuntimeClasspath.get()
+    }
+    processIntegrationTestResources {
+        dependsOn("resolveIntegrationTestDependencies")
+    }
 }
 
 java {


### PR DESCRIPTION
Исправление билда на GA. Он начал падать из-за того, что в новой версии Jenkins плагин durable-task не мог обнаружить себя в списке плагинов. Оказалось, что это [баг ядра Jenkins](https://issues.jenkins.io/browse/JENKINS-48885) и он до сих пор не закрыт.

Способ обхода был найден и честно скопипащен [отсюда](https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/issues/65).
