### PR TITLE
Публикация результатов синтаксического контроля в Allure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ val junitVersion = "5.11.0"
 val spockVersion = "1.3-groovy-2.4"
 val groovyVersion = "2.4.21"
 val slf4jVersion = "2.0.16"
-val jsonschemaVersion = "4.36.0"
+val jsonschemaVersion = "4.37.0"
 
 dependencies {
     implementation("org.codehaus.groovy", "groovy-all", groovyVersion)

--- a/resources/globalConfiguration.json
+++ b/resources/globalConfiguration.json
@@ -64,7 +64,6 @@
   },
   "syntaxCheck": {
     "groupErrorsByMetadata": true,
-    "pathToJUnitReport": "./build/out/jUnit/syntax.xml",
     "exceptionFile": "./tools/syntax-check-exception-file.txt",
     "checkModes": [
       "-ThinClient",
@@ -79,7 +78,9 @@
       "-CheckUseSynchronousCalls",
       "-DistributiveModules"
     ],
-    "vrunnerSettings": "./tools/vrunner.json"
+    "vrunnerSettings": "./tools/vrunner.json",
+    "publishToAllureReport": false,
+    "publishToJUnitReport": true
   },
   "smoke": {
     "vrunnerSettings": "./tools/vrunner.json",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -36,7 +36,7 @@
         "dbgsPort" : {
           "type" : "integer",
           "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия",
-           "default" : 1550
+          "default" : 1550
         },
         "vrunnerSteps" : {
           "description" : "Шаги, запускаемые через vrunner.\n    В каждой строке передается отдельная команда \n    vrunner и ее аргументы (например, \"vanessa --settings ./tools/vrunner.json\").\n    По умолчанию содержит одну команду \"vanessa --settings ./tools/vrunner.json\".\n    ",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -378,9 +378,13 @@
           "type" : "boolean",
           "description" : "Группировать выявленные ошибки по объектам метаданных.\n    По умолчанию включено.\n    "
         },
-        "pathToJUnitReport" : {
-          "type" : "string",
-          "description" : "Путь к файлу отчета jUnit\n    По умолчанию содержит значение \"./build/out/jUnit/syntax.xml\"\n    "
+        "publishToAllureReport" : {
+          "type" : "boolean",
+          "description" : "Выполнять публикацию результатов в отчет Allure.\n    По умолчанию выключено.\n    "
+        },
+        "publishToJUnitReport" : {
+          "type" : "boolean",
+          "description" : "Выполнять публикацию результатов в отчет JUnit.\n    По умолчанию включено.\n    "
         },
         "vrunnerSettings" : {
           "type" : "string",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -30,11 +30,13 @@
       "properties" : {
         "coverage" : {
           "type" : "boolean",
-          "description" : "Выполнять замер покрытия"
+          "description" : "Выполнять замер покрытия",
+          "default" : false
         },
         "dbgsPort" : {
           "type" : "integer",
-          "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия"
+          "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия",
+           "default" : 1550
         },
         "vrunnerSteps" : {
           "description" : "Шаги, запускаемые через vrunner.\n    В каждой строке передается отдельная команда \n    vrunner и ее аргументы (например, \"vanessa --settings ./tools/vrunner.json\").\n    По умолчанию содержит одну команду \"vanessa --settings ./tools/vrunner.json\".\n    ",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -30,13 +30,11 @@
       "properties" : {
         "coverage" : {
           "type" : "boolean",
-          "description" : "Выполнять замер покрытия",
-          "default" : "false"
+          "description" : "Выполнять замер покрытия"
         },
         "dbgsPort" : {
           "type" : "integer",
-          "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия",
-          "default" : "1550"
+          "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия"
         },
         "vrunnerSteps" : {
           "description" : "Шаги, запускаемые через vrunner.\n    В каждой строке передается отдельная команда \n    vrunner и ее аргументы (например, \"vanessa --settings ./tools/vrunner.json\").\n    По умолчанию содержит одну команду \"vanessa --settings ./tools/vrunner.json\".\n    ",
@@ -250,12 +248,12 @@
         "coverage" : {
           "type" : "boolean",
           "description" : "Выполнять замер покрытия",
-          "default" : "false"
+          "default" : false
         },
         "dbgsPort" : {
           "type" : "integer",
           "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия",
-          "default" : "1550"
+          "default" : 1550
         },
         "publishToAllureReport" : {
           "type" : "boolean",
@@ -380,11 +378,13 @@
         },
         "publishToAllureReport" : {
           "type" : "boolean",
-          "description" : "Выполнять публикацию результатов в отчет Allure.\n    По умолчанию выключено.\n    "
+          "description" : "Выполнять публикацию результатов в отчет Allure.\n    По умолчанию выключено.\n    ",
+          "default": false
         },
         "publishToJUnitReport" : {
           "type" : "boolean",
-          "description" : "Выполнять публикацию результатов в отчет JUnit.\n    По умолчанию включено.\n    "
+          "description" : "Выполнять публикацию результатов в отчет JUnit.\n    По умолчанию включено.\n    ",
+          "default": true
         },
         "vrunnerSettings" : {
           "type" : "string",
@@ -473,12 +473,12 @@
         "coverage" : {
           "type" : "boolean",
           "description" : "Выполнять замер покрытия",
-          "default" : "false"
+          "default" : false
         },
         "dbgsPort" : {
           "type" : "integer",
           "description" : "Порт, на котором будет запущен сервер отладки для замера покрытия",
-          "default" : "1550"
+          "default" : 1550
         },
         "publishToAllureReport" : {
           "type" : "boolean",

--- a/src/ru/pulsar/jenkins/library/configuration/SyntaxCheckOptions.groovy
+++ b/src/ru/pulsar/jenkins/library/configuration/SyntaxCheckOptions.groovy
@@ -2,6 +2,8 @@ package ru.pulsar.jenkins.library.configuration
 
 import com.cloudbees.groovy.cps.NonCPS
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -29,12 +31,14 @@ class SyntaxCheckOptions implements Serializable {
     @JsonPropertyDescription("""Выполнять публикацию результатов в отчет Allure.
     По умолчанию выключено.
     """)
-    boolean publishToAllureReport
+    @JsonProperty(defaultValue = "false")
+    boolean publishToAllureReport = false
 
     @JsonPropertyDescription("""Выполнять публикацию результатов в отчет JUnit.
     По умолчанию включено.
     """)
-    boolean publishToJUnitReport
+    @JsonProperty(defaultValue = "true")
+    boolean publishToJUnitReport = true
 
     @Override
     @NonCPS

--- a/src/ru/pulsar/jenkins/library/configuration/SyntaxCheckOptions.groovy
+++ b/src/ru/pulsar/jenkins/library/configuration/SyntaxCheckOptions.groovy
@@ -7,11 +7,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription
 @JsonIgnoreProperties(ignoreUnknown = true)
 class SyntaxCheckOptions implements Serializable {
 
-    @JsonPropertyDescription("""Путь к файлу отчета jUnit
-    По умолчанию содержит значение "./build/out/jUnit/syntax.xml"
-    """)
-    String pathToJUnitReport = "./build/out/jUnit/syntax.xml"
-
     @JsonPropertyDescription("""Группировать выявленные ошибки по объектам метаданных.
     По умолчанию включено.
     """)
@@ -31,14 +26,25 @@ class SyntaxCheckOptions implements Serializable {
     """)
     String vrunnerSettings = "./tools/vrunner.json"
 
+    @JsonPropertyDescription("""Выполнять публикацию результатов в отчет Allure.
+    По умолчанию выключено.
+    """)
+    boolean publishToAllureReport
+
+    @JsonPropertyDescription("""Выполнять публикацию результатов в отчет JUnit.
+    По умолчанию включено.
+    """)
+    boolean publishToJUnitReport
+
     @Override
     @NonCPS
     String toString() {
         return "SyntaxCheckOptions{" +
-            "pathToJUnitReport='" + pathToJUnitReport + '\'' +
             ", groupErrorsByMetadata=" + groupErrorsByMetadata +
             ", checkModes=" + checkModes +
             ", vrunnerSettings=" + vrunnerSettings +
-            '}';
+            ", publishToAllureReport=" + publishToAllureReport +
+            ", publishToJUnitReport=" + publishToJUnitReport +
+            '}'
     }
 }

--- a/src/ru/pulsar/jenkins/library/steps/PublishAllure.groovy
+++ b/src/ru/pulsar/jenkins/library/steps/PublishAllure.groovy
@@ -39,6 +39,9 @@ class PublishAllure implements Serializable {
         if (config.stageFlags.smoke && config.smokeTestOptions.publishToAllureReport) {
             safeUnstash(SmokeTest.ALLURE_STASH)
         }
+        if (config.stageFlags.syntaxCheck && config.syntaxCheckOptions.publishToAllureReport) {
+            safeUnstash(SyntaxCheck.ALLURE_STASH)
+        }
 
         def env = steps.env()
 

--- a/src/ru/pulsar/jenkins/library/steps/SyntaxCheck.groovy
+++ b/src/ru/pulsar/jenkins/library/steps/SyntaxCheck.groovy
@@ -1,0 +1,96 @@
+package ru.pulsar.jenkins.library.steps
+
+import hudson.FilePath
+import ru.pulsar.jenkins.library.IStepExecutor
+import ru.pulsar.jenkins.library.configuration.JobConfiguration
+import ru.pulsar.jenkins.library.ioc.ContextRegistry
+import ru.pulsar.jenkins.library.utils.FileUtils
+import ru.pulsar.jenkins.library.utils.Logger
+import ru.pulsar.jenkins.library.utils.VRunner
+
+class SyntaxCheck {
+
+    public static final String ALLURE_STASH = 'syntax-check-allure'
+
+    private final JobConfiguration config
+
+    SyntaxCheck(JobConfiguration config) {
+        this.config = config
+    }
+
+    def run() {
+        IStepExecutor steps = ContextRegistry.getContext().getStepExecutor()
+
+        Logger.printLocation()
+
+        if (!config.stageFlags.syntaxCheck) {
+            Logger.println("Syntax-check step is disabled")
+            return
+        }
+
+        def env = steps.env()
+
+        def options = config.syntaxCheckOptions
+
+        List<String> logosConfig = ["LOGOS_CONFIG=$config.logosConfig"]
+        steps.withEnv(logosConfig) {
+            steps.installLocalDependencies()
+
+            String junitReport = "build/out/jUnit/syntax-check/syntax-check.xml"
+            FilePath pathToJUnitReport = FileUtils.getFilePath("$env.WORKSPACE/$junitReport")
+            String junitReportDir = FileUtils.getLocalPath(pathToJUnitReport.getParent())
+
+            String allureReport = "build/out/allure/syntax-check/allure.xml"
+            FilePath pathToAllureReport = FileUtils.getFilePath("$env.WORKSPACE/$allureReport")
+            String allureReportDir = FileUtils.getLocalPath(pathToAllureReport.getParent())
+
+            String vrunnerPath = VRunner.getVRunnerPath()
+            String command = "$vrunnerPath syntax-check --ibconnection \"/F./build/ib\""
+
+            // Временно убрал передачу параметра.
+            // См. https://github.com/vanessa-opensource/vanessa-runner/issues/361
+            // command += " --workspace $env.WORKSPACE"
+
+            if (options.groupErrorsByMetadata) {
+                command += ' --groupbymetadata'
+            }
+
+            if (options.publishToJUnitReport) {
+                steps.createDir(junitReportDir)
+                command += " --junitpath $pathToJUnitReport"
+            }
+
+            if (options.publishToAllureReport) {
+                steps.createDir(allureReportDir)
+                command += " --allure-results2 $allureReportDir"
+            }
+
+            FilePath vrunnerSettings = FileUtils.getFilePath("$env.WORKSPACE/$options.vrunnerSettings")
+            if (vrunnerSettings.exists()) {
+                command += " --settings $vrunnerSettings"
+            }
+
+            if (!options.exceptionFile.empty && steps.fileExists(options.exceptionFile)) {
+                command += " --exception-file $options.exceptionFile"
+            }
+
+            if (options.checkModes.length > 0) {
+                def checkModes = options.checkModes.join(" ")
+                command += " --mode $checkModes"
+            }
+
+            // Запуск синтакс-проверки
+            VRunner.exec(command, true)
+
+            if (options.publishToAllureReport) {
+                steps.stash(ALLURE_STASH, "$allureReportDir/**", true)
+                steps.archiveArtifacts("$allureReportDir/**")
+            }
+
+            if (options.publishToJUnitReport) {
+                steps.junit("$junitReportDir/*.xml", true)
+                steps.archiveArtifacts("$junitReportDir/**")
+            }
+        }
+    }
+}

--- a/vars/pipeline1C.groovy
+++ b/vars/pipeline1C.groovy
@@ -248,9 +248,19 @@ void call() {
                             beforeAgent true
                             expression { config.stageFlags.syntaxCheck }
                         }
-                        steps {
-                            timeout(time: config.timeoutOptions.syntaxCheck, unit: TimeUnit.MINUTES) {
-                                syntaxCheck config
+                        stages {
+                            stage('Распаковка ИБ') {
+                                steps {
+                                    unzipInfobase()
+                                }
+                            }
+
+                            stage('Выполнение синтаксического контроля') {
+                                steps {
+                                    timeout(time: config.timeoutOptions.syntaxCheck, unit: TimeUnit.MINUTES) {
+                                        syntaxCheck config
+                                    }
+                                }
                             }
                         }
                     }

--- a/vars/syntaxCheck.groovy
+++ b/vars/syntaxCheck.groovy
@@ -1,64 +1,12 @@
-import hudson.FilePath
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.ioc.ContextRegistry
-import ru.pulsar.jenkins.library.utils.FileUtils
-import ru.pulsar.jenkins.library.utils.VRunner
+import ru.pulsar.jenkins.library.steps.SyntaxCheck
 
 def call(JobConfiguration config) {
 
     ContextRegistry.registerDefaultContext(this)
 
-    // TODO: Вынести в отдельный класс по аналогии с SonarScanner
+    def syntaxCheck = new SyntaxCheck(config)
+    syntaxCheck.run()
 
-    printLocation()
-
-    if (!config.stageFlags.syntaxCheck) {
-        echo("Syntax-check step is disabled")
-        return
-    }
-
-    def options = config.syntaxCheckOptions
-
-    installLocalDependencies()
-
-    unzipInfobase()
-
-    FilePath pathToJUnitReport = FileUtils.getFilePath("$env.WORKSPACE/$options.pathToJUnitReport")
-
-    String outPath = pathToJUnitReport.getParent()
-    createDir(outPath)
-
-    String vrunnerPath = VRunner.getVRunnerPath();
-    String command = "$vrunnerPath syntax-check --ibconnection \"/F./build/ib\""
-
-    // Временно убрал передачу параметра.
-    // См. https://github.com/vanessa-opensource/vanessa-runner/issues/361
-    // command += " --workspace $env.WORKSPACE"
-
-    if (options.groupErrorsByMetadata) {
-        command += ' --groupbymetadata'
-    }
-
-    command += " --junitpath $pathToJUnitReport";
-
-    FilePath vrunnerSettings = FileUtils.getFilePath("$env.WORKSPACE/$options.vrunnerSettings")
-    if (vrunnerSettings.exists()) {
-        command += " --settings $vrunnerSettings";
-    }
-
-    if (!options.exceptionFile.empty && fileExists(options.exceptionFile)) {
-        command += " --exception-file $options.exceptionFile"
-    }
-
-    if (options.checkModes.length > 0) {
-        def checkModes = options.checkModes.join(" ")
-        command += " --mode $checkModes"
-    }
-
-    // Запуск синтакс-проверки
-    VRunner.exec(command, true)
-
-    junit allowEmptyResults: true, testResults: FileUtils.getLocalPath(pathToJUnitReport)
-
-    archiveArtifacts FileUtils.getLocalPath(pathToJUnitReport)
 }


### PR DESCRIPTION
fixes #142 

Заодно перенес код из vars в отдельный класс, + унифицировал параметры и последовательность выполнения с другими этапами.

Я решил, что для той же пресловутой унификации правильнее будет не передавать в Allure результаты jUnit , а сразу выполнять команду vrunner syntax-check с параметром `--allure-results2`.