### PR TITLE
Fix/архивируем результат allure на этапе smoke в отдельный архив и отправляем в артефакты

### DIFF
--- a/src/ru/pulsar/jenkins/library/steps/SmokeTest.groovy
+++ b/src/ru/pulsar/jenkins/library/steps/SmokeTest.groovy
@@ -111,7 +111,11 @@ class SmokeTest implements Serializable, Coverable {
 
             if (options.publishToAllureReport) {
                 steps.stash(ALLURE_STASH, "$allureReportDir/**", true)
-                steps.archiveArtifacts("$allureReportDir/**")
+                
+                // Архивируем результат в отдельный архив и отправляем в артефакты.
+                String archivePath = "build/out/allure/smoke.zip"
+                Boolean archiveArtifacts = true
+                steps.zip("$allureReportDir", archivePath, '', archiveArtifacts)
             }
 
             if (options.publishToJUnitReport) {


### PR DESCRIPTION
Сейчас не архивирует и засоряет артефакты

<img width="743" height="602" alt="image" src="https://github.com/user-attachments/assets/545fdad8-1884-4572-854d-56f6a05352ac" />
