### PR TITLE
Исправления, связанные с переименованием пакета в allure-jenkins-plugin 2.35.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,7 +120,7 @@ sharedLibrary {
         dependency("org.jenkins-ci.modules", "sshd", "3.374.v19b_d59ce6610")
 
         dependency("org.6wind.jenkins", "lockable-resources", "1412.v3f305a_fb_a_117")
-        dependency("org.allurereport", "allure-jenkins-plugin", "2.35.0")
+        dependency("org.allurereport.jenkins", "allure-jenkins-plugin", "2.35.0")
         dependency("io.jenkins.blueocean", "blueocean-pipeline-api-impl", "1.27.21")
         dependency("sp.sd", "file-operations", "353.vf3b_9b_a_f1f7f7")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,7 +120,7 @@ sharedLibrary {
         dependency("org.jenkins-ci.modules", "sshd", "3.374.v19b_d59ce6610")
 
         dependency("org.6wind.jenkins", "lockable-resources", "1412.v3f305a_fb_a_117")
-        dependency("ru.yandex.qatools.allure", "allure-jenkins-plugin", "2.32.0")
+        dependency("org.allurereport", "allure-jenkins-plugin", "2.35.0")
         dependency("io.jenkins.blueocean", "blueocean-pipeline-api-impl", "1.27.21")
         dependency("sp.sd", "file-operations", "353.vf3b_9b_a_f1f7f7")
 

--- a/src/ru/pulsar/jenkins/library/StepExecutor.groovy
+++ b/src/ru/pulsar/jenkins/library/StepExecutor.groovy
@@ -10,7 +10,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.configuration.StepCoverageOptions
 import ru.pulsar.jenkins.library.steps.Coverable
-import ru.yandex.qatools.allure.jenkins.config.ResultsConfig
+import org.allurereport.jenkins.config.ResultsConfig
 import sp.sd.fileoperations.FileOperation
 
 class StepExecutor implements IStepExecutor {


### PR DESCRIPTION
После обновления плагина allure-jenkins-plugin на версию 2.35.0 пайплайн перестает запускаться с такой ошибкой

```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: a2cd684a-9be3-479e-ae97-051f2cd9d93f
org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException: startup failed:
file:/var/jenkins_home/jobs/jenkins-lib-ssl-demo/branches/main/builds/37/libs/f2d251b4a99869e298a6237c10c3fec3ea508aa4833d7e8ffaff9608216ae739/src/ru/pulsar/jenkins/library/StepExecutor.groovy: 13: unable to resolve class ru.yandex.qatools.allure.jenkins.config.ResultsConfig
 @ line 13, column 1.
   import ru.yandex.qatools.allure.jenkins.config.ResultsConfig
   ^
```

Вот [тут](https://github.com/jenkinsci/allure-plugin/pull/411/changes) видно, что изменилось имя пакета.

Получается, проще всего обновить импорт и зависимости в jenkins-lib, а также потребовать от пользователей современной версии библиотеки обновить плагин до 2.35.0.