### PR TITLE
fix: remove hard dependency on Allure ResultsConfig in shared library

### DIFF
--- a/src/ru/pulsar/jenkins/library/StepExecutor.groovy
+++ b/src/ru/pulsar/jenkins/library/StepExecutor.groovy
@@ -10,7 +10,6 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.configuration.StepCoverageOptions
 import ru.pulsar.jenkins.library.steps.Coverable
-import ru.yandex.qatools.allure.jenkins.config.ResultsConfig
 import sp.sd.fileoperations.FileOperation
 
 class StepExecutor implements IStepExecutor {
@@ -252,7 +251,7 @@ class StepExecutor implements IStepExecutor {
             jdk: '',
             properties: [],
             reportBuildPolicy: 'ALWAYS',
-            results: ResultsConfig.convertPaths(results)
+            results: results.collect { [path: it] }
         ])
     }
 


### PR DESCRIPTION
После обновления Jenkins/Allure plugin shared library перестала компилироваться с ошибкой `unable to resolve class ru.yandex.qatools.allure.jenkins.config.ResultsConfig`.

Закрывает: #199

В PR убран прямой импорт `ResultsConfig` в `StepExecutor.groovy`, формирование параметра Allure переведено на стандартный pipeline-формат:
`results: results.collect { [path: it] }`.

Это восстанавливает совместимость с актуальными версиями Allure Jenkins Plugin и устраняет падение на этапе компиляции pipeline.