### PR TITLE
fix: remove hard dependency on Allure ResultsConfig in shared library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,7 +120,6 @@ sharedLibrary {
         dependency("org.jenkins-ci.modules", "sshd", "3.374.v19b_d59ce6610")
 
         dependency("org.6wind.jenkins", "lockable-resources", "1412.v3f305a_fb_a_117")
-        dependency("ru.yandex.qatools.allure", "allure-jenkins-plugin", "2.32.0")
         dependency("io.jenkins.blueocean", "blueocean-pipeline-api-impl", "1.27.21")
         dependency("sp.sd", "file-operations", "353.vf3b_9b_a_f1f7f7")
 

--- a/src/ru/pulsar/jenkins/library/StepExecutor.groovy
+++ b/src/ru/pulsar/jenkins/library/StepExecutor.groovy
@@ -10,7 +10,6 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 import ru.pulsar.jenkins.library.configuration.JobConfiguration
 import ru.pulsar.jenkins.library.configuration.StepCoverageOptions
 import ru.pulsar.jenkins.library.steps.Coverable
-import ru.yandex.qatools.allure.jenkins.config.ResultsConfig
 import sp.sd.fileoperations.FileOperation
 
 class StepExecutor implements IStepExecutor {
@@ -252,7 +251,7 @@ class StepExecutor implements IStepExecutor {
             jdk: '',
             properties: [],
             reportBuildPolicy: 'ALWAYS',
-            results: ResultsConfig.convertPaths(results)
+            results: results.collect { [path: it] }
         ])
     }
 


### PR DESCRIPTION
После обновления Jenkins/Allure plugin shared library перестала компилироваться с ошибкой `unable to resolve class ru.yandex.qatools.allure.jenkins.config.ResultsConfig`.

Закрывает: #199

В PR убран прямой импорт `ResultsConfig` в `StepExecutor.groovy`, формирование параметра Allure переведено на стандартный pipeline-формат:
`results: results.collect { [path: it] }`.

Это восстанавливает совместимость с актуальными версиями Allure Jenkins Plugin и устраняет падение на этапе компиляции pipeline.