### PR TITLE
fix: Использовать exit code команды vrunner при отсутствии файла статуса миграции ИБ

### DIFF
--- a/src/ru/pulsar/jenkins/library/steps/InitInfoBase.groovy
+++ b/src/ru/pulsar/jenkins/library/steps/InitInfoBase.groovy
@@ -60,8 +60,8 @@ class InitInfoBase implements Serializable {
                 command += " --exitCodePath \"${migrationStatusFile}\""
                 // Запуск миграции
                 steps.catchError {
-                    VRunner.exec(command, true)
-                    exitStatuses.put(command, VRunner.readExitStatusFromFile(migrationStatusFile))
+                    Integer exitStatus = VRunner.exec(command, true)
+                    exitStatuses.put(command, VRunner.readExitStatusFromFile(migrationStatusFile, exitStatus))
                 }
             } else {
                 Logger.println("Шаг миграции ИБ выключен")

--- a/src/ru/pulsar/jenkins/library/utils/VRunner.groovy
+++ b/src/ru/pulsar/jenkins/library/utils/VRunner.groovy
@@ -58,7 +58,7 @@ class VRunner {
                 return content.toInteger()
             }
         } catch (NoSuchFileException e) {
-            Logger.println("Файл со статусом возврата ${path} не найден: ${e.message}")
+            Logger.println("Файл со статусом возврата ${path} не найден: ${e.message}. Будет использован переданный статус ${valueIfNoSuchFile}")
             return valueIfNoSuchFile
         } catch (NumberFormatException e) {
             Logger.println("В файле со статусом возврата ${path} записано не числовое значение: ${e.message}")

--- a/test/unit/groovy/ru/pulsar/jenkins/library/steps/InitInfoBaseTest.java
+++ b/test/unit/groovy/ru/pulsar/jenkins/library/steps/InitInfoBaseTest.java
@@ -1,0 +1,73 @@
+package ru.pulsar.jenkins.library.steps;
+
+import groovy.lang.Closure;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import ru.pulsar.jenkins.library.IStepExecutor;
+import ru.pulsar.jenkins.library.configuration.ConfigurationReader;
+import ru.pulsar.jenkins.library.configuration.JobConfiguration;
+import ru.pulsar.jenkins.library.utils.TestUtils;
+import ru.pulsar.jenkins.library.utils.VRunner;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InitInfoBaseTest {
+
+    private IStepExecutor steps;
+
+    @BeforeEach
+    void setUp() {
+        steps = TestUtils.getMockedStepExecutor();
+
+        when(steps.withEnv(anyList(), any(Closure.class)))
+                .thenAnswer(invocation -> {
+                    Closure<?> body = invocation.getArgument(1);
+                    return body.call();
+                });
+
+        when(steps.catchError(any(Closure.class)))
+                .thenAnswer(invocation -> {
+                    Closure<?> body = invocation.getArgument(0);
+                    return body.call();
+                });
+
+        TestUtils.setupMockedContext(steps);
+    }
+
+    @Test
+    void runUsesCommandExitStatusWhenMigrationStatusFileIsMissing() throws IOException {
+
+        // given
+        String config = IOUtils.resourceToString(
+                "initInfoBaseRunMigration.json",
+                StandardCharsets.UTF_8,
+                this.getClass().getClassLoader()
+        );
+        JobConfiguration jobConfiguration = ConfigurationReader.create(config);
+
+        try (MockedStatic<VRunner> vrunner = Mockito.mockStatic(VRunner.class)) {
+            vrunner.when(VRunner::getVRunnerPath).thenReturn("vrunner");
+            vrunner.when(() -> VRunner.exec(anyString(), eq(true))).thenReturn(0);
+            vrunner.when(() -> VRunner.readExitStatusFromFile("build/migration-exit-status.log", 0)).thenReturn(0);
+
+            // when
+            new InitInfoBase(jobConfiguration).run();
+
+            // then
+            vrunner.verify(() -> VRunner.readExitStatusFromFile("build/migration-exit-status.log", 0));
+            verify(steps, never()).error(anyString());
+        }
+    }
+}

--- a/test/unit/groovy/ru/pulsar/jenkins/library/utils/VRunnerTest.java
+++ b/test/unit/groovy/ru/pulsar/jenkins/library/utils/VRunnerTest.java
@@ -58,5 +58,18 @@ class VRunnerTest {
         assertThat(exitStatus).isEqualTo(1);
 
     }
+
+    @Test
+    void readExitStatusFromFile_does_not_exist_uses_provided_fallback() {
+
+        // given
+        String resource = "exitStatusDoesNotExist";
+
+        // when
+        Integer exitStatus = VRunner.readExitStatusFromFile(resource, 0);
+        // then
+        assertThat(exitStatus).isEqualTo(0);
+
+    }
 }
 

--- a/test/unit/resources/initInfoBaseRunMigration.json
+++ b/test/unit/resources/initInfoBaseRunMigration.json
@@ -1,0 +1,11 @@
+{
+  "stages": {
+    "initSteps": true
+  },
+  "initInfobase": {
+    "runMigration": true,
+    "additionalInitializationSteps": [
+      "vanessa --settings ./tools/vrunner.first.json"
+    ]
+  }
+}


### PR DESCRIPTION
Closes #189

## Что и зачем

После добавления `--exitCodePath` в шаг миграции ИБ (`InitInfoBase`) сборка падала с ошибкой
`Получен неожиданный/неверный результат работы - Не найден файл статуса build/migration-exit-status.log`
для конфигураций без БСП: обработка `ЗакрытьПредприятие.epf` не отрабатывает,
файл со статусом не создаётся, и текущая логика всегда трактовала это как ошибку
(дефолтный fallback `1` в `VRunner.readExitStatusFromFile`).

## Решение

Универсальное, без проверки «БСП / не БСП»:

- В `InitInfoBase` сохраняем код возврата самой команды `VRunner.exec(...)` и пробрасываем его
  как fallback в `VRunner.readExitStatusFromFile(migrationStatusFile, exitStatus)`.
- Если файл статуса есть — читаем его (поведение для БСП-кейсов не меняется).
- Если файла нет — используем фактический exit code команды vrunner, как было до
  появления `--exitCodePath`.
- В `VRunner.readExitStatusFromFile` уточнено лог-сообщение: теперь явно видно,
  какое значение будет использовано вместо отсутствующего файла.

## Совместимость

- БСП-кейс: файл статуса создаётся как раньше — поведение идентично прежнему.
- Не-БСП кейс: больше нет ложного падения шага; статус берётся из exit code команды.

## Изменённые файлы

- `src/ru/pulsar/jenkins/library/steps/InitInfoBase.groovy` — fallback на exit code команды.
- `src/ru/pulsar/jenkins/library/utils/VRunner.groovy` — уточнено лог-сообщение об отсутствии файла.
- `test/unit/groovy/ru/pulsar/jenkins/library/steps/InitInfoBaseTest.java` — новый unit-тест на сценарий из issue.
- `test/unit/resources/initInfoBaseRunMigration.json` — фикстура для теста.
- `test/unit/groovy/ru/pulsar/jenkins/library/utils/VRunnerTest.java` — кейс для перегрузки с кастомным fallback.

## Проверка

- `./gradlew test --tests "ru.pulsar.jenkins.library.steps.InitInfoBaseTest" --tests "ru.pulsar.jenkins.library.utils.VRunnerTest"` — зелёный.